### PR TITLE
Estilizacao login cadastro

### DIFF
--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -13,16 +13,19 @@
 
   * { box-sizing: border-box; margin: 0; padding: 0; }
 
-  body.devise-passwords {
-    min-height: 100vh;
+  body {
     background-color: var(--creme);
-    font-family: 'DM Sans', sans-serif;
-    display: flex;
-    align-items: center;
-    justify-content: center;
     background-image:
       radial-gradient(ellipse 60% 50% at 10% 20%, rgba(45,106,79,.08) 0%, transparent 70%),
       radial-gradient(ellipse 50% 60% at 90% 80%, rgba(64,145,108,.07) 0%, transparent 70%);
+    font-family: 'DM Sans', sans-serif;
+  }
+
+  .auth-layout {
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     padding: 2rem 1rem;
   }
 
@@ -31,7 +34,6 @@
     max-width: 420px;
   }
 
-  /* ---- marca ---- */
   .auth-brand {
     text-align: center;
     margin-bottom: 2.5rem;
@@ -73,7 +75,6 @@
     margin-top: .35rem;
   }
 
-  /* ---- card ---- */
   .auth-card {
     background: #fff;
     border-radius: 20px;
@@ -84,7 +85,6 @@
     border: 1px solid rgba(0,0,0,.055);
   }
 
-  /* ---- ícone de cadeado no topo do card ---- */
   .card-icon {
     display: inline-flex;
     align-items: center;
@@ -115,14 +115,13 @@
     margin-bottom: .5rem;
   }
 
-  .auth-card .card-description {
+  .card-description {
     font-size: .875rem;
     color: var(--cinza);
     line-height: 1.55;
     margin-bottom: 1.75rem;
   }
 
-  /* ---- erros ---- */
   .auth-errors {
     background: #FEF2F2;
     border: 1px solid #FECACA;
@@ -136,10 +135,7 @@
   .auth-errors ul { padding-left: 1.1rem; }
   .auth-errors li { margin-top: .2rem; }
 
-  /* ---- campo ---- */
-  .field-group {
-    margin-bottom: 1.25rem;
-  }
+  .field-group { margin-bottom: 1.25rem; }
 
   .field-group label {
     display: block;
@@ -170,7 +166,6 @@
     box-shadow: 0 0 0 3px rgba(64,145,108,.12);
   }
 
-  /* ---- botão ---- */
   .btn-primary-auth {
     display: block;
     width: 100%;
@@ -193,11 +188,8 @@
     transform: translateY(-1px);
   }
 
-  .btn-primary-auth:active {
-    transform: translateY(0);
-  }
+  .btn-primary-auth:active { transform: translateY(0); }
 
-  /* ---- links rodapé ---- */
   .auth-links {
     margin-top: 1.5rem;
     display: flex;
@@ -241,10 +233,9 @@
   }
 </style>
 
-<body class="devise-passwords">
+<main class="auth-layout devise-passwords">
   <div class="auth-wrapper">
 
-    <%# Marca %>
     <div class="auth-brand">
       <div class="brand-icon">
         <svg viewBox="0 0 24 24">
@@ -306,4 +297,4 @@
     </div>
 
   </div>
-</body>
+</main>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,16 +1,309 @@
-<h2>Forgot your password?</h2>
+<%# app/views/devise/passwords/new.html.erb %>
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=Fraunces:ital,wght@0,300;0,400;0,600;1,300&family=DM+Sans:wght@300;400;500&display=swap');
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+  :root {
+    --verde:    #2D6A4F;
+    --verde-md: #40916C;
+    --verde-lt: #B7E4C7;
+    --creme:    #F8F4EE;
+    --texto:    #1A1A1A;
+    --cinza:    #6B7280;
+  }
 
-  <div class="field">
-    <p><%= f.label :email %></p>
-    <p><%= f.email_field :email, autofocus: true, autocomplete: "email" %></p>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+
+  body.devise-passwords {
+    min-height: 100vh;
+    background-color: var(--creme);
+    font-family: 'DM Sans', sans-serif;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-image:
+      radial-gradient(ellipse 60% 50% at 10% 20%, rgba(45,106,79,.08) 0%, transparent 70%),
+      radial-gradient(ellipse 50% 60% at 90% 80%, rgba(64,145,108,.07) 0%, transparent 70%);
+    padding: 2rem 1rem;
+  }
+
+  .auth-wrapper {
+    width: 100%;
+    max-width: 420px;
+  }
+
+  /* ---- marca ---- */
+  .auth-brand {
+    text-align: center;
+    margin-bottom: 2.5rem;
+  }
+
+  .auth-brand .brand-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 56px;
+    height: 56px;
+    background: var(--verde);
+    border-radius: 16px;
+    margin-bottom: 1rem;
+    box-shadow: 0 4px 16px rgba(45,106,79,.25);
+  }
+
+  .auth-brand .brand-icon svg {
+    width: 28px;
+    height: 28px;
+    color: #fff;
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 2;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
+
+  .auth-brand h1 {
+    font-family: 'Fraunces', serif;
+    font-weight: 600;
+    font-size: 1.5rem;
+    color: var(--texto);
+  }
+
+  .auth-brand p {
+    font-size: .875rem;
+    color: var(--cinza);
+    margin-top: .35rem;
+  }
+
+  /* ---- card ---- */
+  .auth-card {
+    background: #fff;
+    border-radius: 20px;
+    padding: 2.5rem 2.25rem;
+    box-shadow:
+      0 1px 3px rgba(0,0,0,.04),
+      0 8px 32px rgba(0,0,0,.07);
+    border: 1px solid rgba(0,0,0,.055);
+  }
+
+  /* ---- ícone de cadeado no topo do card ---- */
+  .card-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 48px;
+    height: 48px;
+    background: #F0FDF4;
+    border: 1.5px solid var(--verde-lt);
+    border-radius: 12px;
+    margin-bottom: 1.25rem;
+  }
+
+  .card-icon svg {
+    width: 22px;
+    height: 22px;
+    fill: none;
+    stroke: var(--verde);
+    stroke-width: 2;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
+
+  .auth-card h2 {
+    font-family: 'Fraunces', serif;
+    font-weight: 400;
+    font-size: 1.6rem;
+    color: var(--texto);
+    margin-bottom: .5rem;
+  }
+
+  .auth-card .card-description {
+    font-size: .875rem;
+    color: var(--cinza);
+    line-height: 1.55;
+    margin-bottom: 1.75rem;
+  }
+
+  /* ---- erros ---- */
+  .auth-errors {
+    background: #FEF2F2;
+    border: 1px solid #FECACA;
+    border-radius: 10px;
+    padding: .85rem 1rem;
+    margin-bottom: 1.25rem;
+    font-size: .85rem;
+    color: #B91C1C;
+  }
+
+  .auth-errors ul { padding-left: 1.1rem; }
+  .auth-errors li { margin-top: .2rem; }
+
+  /* ---- campo ---- */
+  .field-group {
+    margin-bottom: 1.25rem;
+  }
+
+  .field-group label {
+    display: block;
+    font-size: .78rem;
+    font-weight: 500;
+    letter-spacing: .04em;
+    text-transform: uppercase;
+    color: var(--cinza);
+    margin-bottom: .45rem;
+  }
+
+  .field-group input[type="email"] {
+    width: 100%;
+    padding: .7rem .95rem;
+    border: 1.5px solid #E5E7EB;
+    border-radius: 10px;
+    font-family: 'DM Sans', sans-serif;
+    font-size: .95rem;
+    color: var(--texto);
+    background: #FAFAFA;
+    transition: border-color .18s, box-shadow .18s, background .18s;
+    outline: none;
+  }
+
+  .field-group input[type="email"]:focus {
+    border-color: var(--verde-md);
+    background: #fff;
+    box-shadow: 0 0 0 3px rgba(64,145,108,.12);
+  }
+
+  /* ---- botão ---- */
+  .btn-primary-auth {
+    display: block;
+    width: 100%;
+    padding: .82rem;
+    background: var(--verde);
+    color: #fff;
+    border: none;
+    border-radius: 10px;
+    font-family: 'DM Sans', sans-serif;
+    font-size: .95rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: background .18s, transform .12s, box-shadow .18s;
+    box-shadow: 0 2px 8px rgba(45,106,79,.25);
+  }
+
+  .btn-primary-auth:hover {
+    background: var(--verde-md);
+    box-shadow: 0 4px 16px rgba(45,106,79,.3);
+    transform: translateY(-1px);
+  }
+
+  .btn-primary-auth:active {
+    transform: translateY(0);
+  }
+
+  /* ---- links rodapé ---- */
+  .auth-links {
+    margin-top: 1.5rem;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: .6rem;
+    font-size: .875rem;
+  }
+
+  .auth-links a {
+    color: var(--verde);
+    text-decoration: none;
+    font-weight: 500;
+    display: inline-flex;
+    align-items: center;
+    gap: .35rem;
+    transition: color .15s;
+  }
+
+  .auth-links a:hover {
+    color: var(--verde-md);
+    text-decoration: underline;
+  }
+
+  .auth-links a svg {
+    width: 14px;
+    height: 14px;
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 2.5;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
+
+  .auth-links .muted { color: var(--cinza); }
+
+  .auth-links .row {
+    display: flex;
+    align-items: center;
+    gap: .5rem;
+  }
+</style>
+
+<body class="devise-passwords">
+  <div class="auth-wrapper">
+
+    <%# Marca %>
+    <div class="auth-brand">
+      <div class="brand-icon">
+        <svg viewBox="0 0 24 24">
+          <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/>
+          <polyline points="9 22 9 12 15 12 15 22"/>
+        </svg>
+      </div>
+      <h1>Gestão de Repúblicas</h1>
+      <p>Controle financeiro da sua república</p>
+    </div>
+
+    <div class="auth-card">
+
+      <div class="card-icon">
+        <svg viewBox="0 0 24 24">
+          <rect x="3" y="11" width="18" height="11" rx="2" ry="2"/>
+          <path d="M7 11V7a5 5 0 0 1 10 0v4"/>
+        </svg>
+      </div>
+
+      <h2>Redefinir senha</h2>
+      <p class="card-description">
+        Informe o e-mail cadastrado na sua conta. Você receberá um link para criar uma nova senha.
+      </p>
+
+      <% if resource.errors.any? %>
+        <div class="auth-errors">
+          <strong><%= pluralize(resource.errors.count, "erro") %> encontrado<%= resource.errors.count > 1 ? "s" : "" %>:</strong>
+          <ul>
+            <% resource.errors.full_messages.each do |msg| %>
+              <li><%= msg %></li>
+            <% end %>
+          </ul>
+        </div>
+      <% end %>
+
+      <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
+
+        <div class="field-group">
+          <%= f.label :email, "E-mail" %>
+          <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+        </div>
+
+        <%= f.submit "Enviar instruções", class: "btn-primary-auth" %>
+
+      <% end %>
+
+      <div class="auth-links">
+        <%= link_to new_session_path(resource_name) do %>
+          <svg viewBox="0 0 24 24"><polyline points="15 18 9 12 15 6"/></svg>
+          Voltar para o login
+        <% end %>
+        <div class="row">
+          <span class="muted">Não tem conta?</span>
+          <%= link_to "Criar conta", new_registration_path(resource_name) %>
+        </div>
+      </div>
+
+    </div>
+
   </div>
-
-  <div class="actions">
-    <%= f.submit "Send me password reset instructions" %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</body>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,46 +1,337 @@
-<h2>Criar Conta</h2>
+<%# app/views/devise/registrations/new.html.erb %>
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=Fraunces:ital,wght@0,300;0,400;0,600;1,300&family=DM+Sans:wght@300;400;500&display=swap');
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+  :root {
+    --verde:    #2D6A4F;
+    --verde-md: #40916C;
+    --verde-lt: #B7E4C7;
+    --creme:    #F8F4EE;
+    --terra:    #6B4226;
+    --texto:    #1A1A1A;
+    --cinza:    #6B7280;
+  }
 
-  <div>
-    <%= f.label :first_name, "Nome" %><br>
-    <%= f.text_field :first_name %>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+
+  body.devise-registrations {
+    min-height: 100vh;
+    background-color: var(--creme);
+    font-family: 'DM Sans', sans-serif;
+    display: flex;
+    align-items: flex-start;
+    justify-content: center;
+    background-image:
+      radial-gradient(ellipse 60% 50% at 10% 20%, rgba(45,106,79,.08) 0%, transparent 70%),
+      radial-gradient(ellipse 50% 60% at 90% 80%, rgba(64,145,108,.07) 0%, transparent 70%);
+    padding: 2.5rem 1rem;
+  }
+
+  .auth-wrapper {
+    width: 100%;
+    max-width: 480px;
+  }
+
+  /* ---- marca ---- */
+  .auth-brand {
+    text-align: center;
+    margin-bottom: 2rem;
+  }
+
+  .auth-brand .brand-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 56px;
+    height: 56px;
+    background: var(--verde);
+    border-radius: 16px;
+    margin-bottom: 1rem;
+    box-shadow: 0 4px 16px rgba(45,106,79,.25);
+  }
+
+  .auth-brand .brand-icon svg {
+    width: 28px;
+    height: 28px;
+    color: #fff;
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 2;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
+
+  .auth-brand h1 {
+    font-family: 'Fraunces', serif;
+    font-weight: 600;
+    font-size: 1.5rem;
+    color: var(--texto);
+  }
+
+  .auth-brand p {
+    font-size: .875rem;
+    color: var(--cinza);
+    margin-top: .35rem;
+  }
+
+  /* ---- card ---- */
+  .auth-card {
+    background: #fff;
+    border-radius: 20px;
+    padding: 2.5rem 2.25rem;
+    box-shadow:
+      0 1px 3px rgba(0,0,0,.04),
+      0 8px 32px rgba(0,0,0,.07);
+    border: 1px solid rgba(0,0,0,.055);
+  }
+
+  .auth-card h2 {
+    font-family: 'Fraunces', serif;
+    font-weight: 400;
+    font-size: 1.6rem;
+    color: var(--texto);
+    margin-bottom: 1.75rem;
+  }
+
+  /* ---- erros ---- */
+  .auth-errors {
+    background: #FEF2F2;
+    border: 1px solid #FECACA;
+    border-radius: 10px;
+    padding: .85rem 1rem;
+    margin-bottom: 1.25rem;
+    font-size: .85rem;
+    color: #B91C1C;
+  }
+
+  .auth-errors ul { padding-left: 1.1rem; }
+  .auth-errors li { margin-top: .2rem; }
+
+  /* ---- grade de 2 colunas ---- */
+  .fields-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0 1rem;
+  }
+
+  .fields-grid .field-group.full {
+    grid-column: 1 / -1;
+  }
+
+  /* ---- campo ---- */
+  .field-group {
+    margin-bottom: 1.15rem;
+  }
+
+  .field-group label {
+    display: block;
+    font-size: .78rem;
+    font-weight: 500;
+    letter-spacing: .04em;
+    text-transform: uppercase;
+    color: var(--cinza);
+    margin-bottom: .4rem;
+  }
+
+  .field-group input[type="email"],
+  .field-group input[type="password"],
+  .field-group input[type="text"] {
+    width: 100%;
+    padding: .68rem .9rem;
+    border: 1.5px solid #E5E7EB;
+    border-radius: 10px;
+    font-family: 'DM Sans', sans-serif;
+    font-size: .92rem;
+    color: var(--texto);
+    background: #FAFAFA;
+    transition: border-color .18s, box-shadow .18s, background .18s;
+    outline: none;
+  }
+
+  .field-group input:focus {
+    border-color: var(--verde-md);
+    background: #fff;
+    box-shadow: 0 0 0 3px rgba(64,145,108,.12);
+  }
+
+  /* ---- dica de campo ---- */
+  .field-hint {
+    font-size: .75rem;
+    color: #9CA3AF;
+    margin-top: .3rem;
+  }
+
+  /* ---- divisor de seção ---- */
+  .section-divider {
+    display: flex;
+    align-items: center;
+    gap: .75rem;
+    margin: 1.5rem 0 1.25rem;
+    color: #D1D5DB;
+    font-size: .78rem;
+    letter-spacing: .05em;
+    text-transform: uppercase;
+    color: var(--cinza);
+  }
+
+  .section-divider::before,
+  .section-divider::after {
+    content: '';
+    flex: 1;
+    height: 1px;
+    background: #E5E7EB;
+  }
+
+  /* ---- botão ---- */
+  .btn-primary-auth {
+    display: block;
+    width: 100%;
+    padding: .82rem;
+    background: var(--verde);
+    color: #fff;
+    border: none;
+    border-radius: 10px;
+    font-family: 'DM Sans', sans-serif;
+    font-size: .95rem;
+    font-weight: 500;
+    cursor: pointer;
+    margin-top: 1.75rem;
+    transition: background .18s, transform .12s, box-shadow .18s;
+    box-shadow: 0 2px 8px rgba(45,106,79,.25);
+  }
+
+  .btn-primary-auth:hover {
+    background: var(--verde-md);
+    box-shadow: 0 4px 16px rgba(45,106,79,.3);
+    transform: translateY(-1px);
+  }
+
+  .btn-primary-auth:active {
+    transform: translateY(0);
+  }
+
+  /* ---- links rodapé ---- */
+  .auth-links {
+    margin-top: 1.5rem;
+    text-align: center;
+    font-size: .875rem;
+  }
+
+  .auth-links .muted { color: var(--cinza); }
+
+  .auth-links a {
+    color: var(--verde);
+    text-decoration: none;
+    font-weight: 500;
+    transition: color .15s;
+  }
+
+  .auth-links a:hover {
+    color: var(--verde-md);
+    text-decoration: underline;
+  }
+
+  /* ---- responsivo ---- */
+  @media (max-width: 480px) {
+    .fields-grid {
+      grid-template-columns: 1fr;
+    }
+    .fields-grid .field-group.full {
+      grid-column: 1;
+    }
+    .auth-card {
+      padding: 2rem 1.5rem;
+    }
+  }
+</style>
+
+<body class="devise-registrations">
+  <div class="auth-wrapper">
+
+    <%# Marca %>
+    <div class="auth-brand">
+      <div class="brand-icon">
+        <svg viewBox="0 0 24 24">
+          <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/>
+          <polyline points="9 22 9 12 15 12 15 22"/>
+        </svg>
+      </div>
+      <h1>Gestão de Repúblicas</h1>
+      <p>Crie sua conta e comece a organizar as finanças</p>
+    </div>
+
+    <div class="auth-card">
+      <h2>Criar Conta</h2>
+
+      <% if resource.errors.any? %>
+        <div class="auth-errors">
+          <strong><%= pluralize(resource.errors.count, "erro") %> encontrado<%= resource.errors.count > 1 ? "s" : "" %>:</strong>
+          <ul>
+            <% resource.errors.full_messages.each do |msg| %>
+              <li><%= msg %></li>
+            <% end %>
+          </ul>
+        </div>
+      <% end %>
+
+      <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+
+        <%# Dados pessoais %>
+        <div class="fields-grid">
+          <div class="field-group">
+            <%= f.label :first_name, "Nome" %>
+            <%= f.text_field :first_name, autocomplete: "given-name" %>
+          </div>
+
+          <div class="field-group">
+            <%= f.label :last_name, "Sobrenome" %>
+            <%= f.text_field :last_name, autocomplete: "family-name" %>
+          </div>
+
+          <div class="field-group">
+            <%= f.label :phone, "Telefone" %>
+            <%= f.text_field :phone, placeholder: "35999999999", autocomplete: "tel" %>
+            <p class="field-hint">Somente números: DDD + número</p>
+          </div>
+
+          <div class="field-group">
+            <%= f.label :document, "CPF" %>
+            <%= f.text_field :document, placeholder: "12345678901", autocomplete: "off" %>
+            <p class="field-hint">Somente números, sem pontos</p>
+          </div>
+        </div>
+
+        <div class="section-divider">Acesso</div>
+
+        <div class="field-group">
+          <%= f.label :email, "E-mail" %>
+          <%= f.email_field :email, autocomplete: "email" %>
+        </div>
+
+        <div class="fields-grid">
+          <div class="field-group">
+            <%= f.label :password, "Senha" %>
+            <%= f.password_field :password, autocomplete: "new-password" %>
+            <% if @minimum_password_length %>
+              <p class="field-hint">Mínimo de <%= @minimum_password_length %> caracteres</p>
+            <% end %>
+          </div>
+
+          <div class="field-group">
+            <%= f.label :password_confirmation, "Confirmar senha" %>
+            <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+          </div>
+        </div>
+
+        <%= f.submit "Criar conta", class: "btn-primary-auth" %>
+
+      <% end %>
+
+      <div class="auth-links">
+        <span class="muted">Já tem uma conta?</span>
+        <%= link_to " Fazer login", new_session_path(resource_name) %>
+      </div>
+    </div>
+
   </div>
-
-  <div>
-    <%= f.label :last_name, "Sobrenome" %><br>
-    <%= f.text_field :last_name %>
-  </div>
-
-  <div>
-    <%= f.label :phone, "Telefone" %><br>
-    <%= f.text_field :phone %>
-  </div>
-
-  <div>
-    <%= f.label :document, "Documento" %><br>
-    <%= f.text_field :document %>
-  </div>
-
-  <div>
-    <%= f.label :email, "E-mail" %><br>
-    <%= f.email_field :email %>
-  </div>
-
-  <div>
-    <%= f.label :password, "Senha" %><br>
-    <%= f.password_field :password %>
-  </div>
-
-  <div>
-    <%= f.label :password_confirmation, "Confirmar senha" %><br>
-    <%= f.password_field :password_confirmation %>
-  </div>
-
-  <div>
-    <%= f.submit "Cadastrar" %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</body>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -7,23 +7,25 @@
     --verde-md: #40916C;
     --verde-lt: #B7E4C7;
     --creme:    #F8F4EE;
-    --terra:    #6B4226;
     --texto:    #1A1A1A;
     --cinza:    #6B7280;
   }
 
   * { box-sizing: border-box; margin: 0; padding: 0; }
 
-  body.devise-registrations {
-    min-height: 100vh;
+  body {
     background-color: var(--creme);
-    font-family: 'DM Sans', sans-serif;
-    display: flex;
-    align-items: flex-start;
-    justify-content: center;
     background-image:
       radial-gradient(ellipse 60% 50% at 10% 20%, rgba(45,106,79,.08) 0%, transparent 70%),
       radial-gradient(ellipse 50% 60% at 90% 80%, rgba(64,145,108,.07) 0%, transparent 70%);
+    font-family: 'DM Sans', sans-serif;
+  }
+
+  .auth-layout {
+    min-height: 100vh;
+    display: flex;
+    align-items: flex-start;
+    justify-content: center;
     padding: 2.5rem 1rem;
   }
 
@@ -32,7 +34,6 @@
     max-width: 480px;
   }
 
-  /* ---- marca ---- */
   .auth-brand {
     text-align: center;
     margin-bottom: 2rem;
@@ -74,7 +75,6 @@
     margin-top: .35rem;
   }
 
-  /* ---- card ---- */
   .auth-card {
     background: #fff;
     border-radius: 20px;
@@ -93,7 +93,6 @@
     margin-bottom: 1.75rem;
   }
 
-  /* ---- erros ---- */
   .auth-errors {
     background: #FEF2F2;
     border: 1px solid #FECACA;
@@ -107,7 +106,6 @@
   .auth-errors ul { padding-left: 1.1rem; }
   .auth-errors li { margin-top: .2rem; }
 
-  /* ---- grade de 2 colunas ---- */
   .fields-grid {
     display: grid;
     grid-template-columns: 1fr 1fr;
@@ -118,10 +116,7 @@
     grid-column: 1 / -1;
   }
 
-  /* ---- campo ---- */
-  .field-group {
-    margin-bottom: 1.15rem;
-  }
+  .field-group { margin-bottom: 1.15rem; }
 
   .field-group label {
     display: block;
@@ -154,20 +149,17 @@
     box-shadow: 0 0 0 3px rgba(64,145,108,.12);
   }
 
-  /* ---- dica de campo ---- */
   .field-hint {
     font-size: .75rem;
     color: #9CA3AF;
     margin-top: .3rem;
   }
 
-  /* ---- divisor de seção ---- */
   .section-divider {
     display: flex;
     align-items: center;
     gap: .75rem;
     margin: 1.5rem 0 1.25rem;
-    color: #D1D5DB;
     font-size: .78rem;
     letter-spacing: .05em;
     text-transform: uppercase;
@@ -182,7 +174,6 @@
     background: #E5E7EB;
   }
 
-  /* ---- botão ---- */
   .btn-primary-auth {
     display: block;
     width: 100%;
@@ -206,11 +197,8 @@
     transform: translateY(-1px);
   }
 
-  .btn-primary-auth:active {
-    transform: translateY(0);
-  }
+  .btn-primary-auth:active { transform: translateY(0); }
 
-  /* ---- links rodapé ---- */
   .auth-links {
     margin-top: 1.5rem;
     text-align: center;
@@ -231,24 +219,16 @@
     text-decoration: underline;
   }
 
-  /* ---- responsivo ---- */
   @media (max-width: 480px) {
-    .fields-grid {
-      grid-template-columns: 1fr;
-    }
-    .fields-grid .field-group.full {
-      grid-column: 1;
-    }
-    .auth-card {
-      padding: 2rem 1.5rem;
-    }
+    .fields-grid { grid-template-columns: 1fr; }
+    .fields-grid .field-group.full { grid-column: 1; }
+    .auth-card { padding: 2rem 1.5rem; }
   }
 </style>
 
-<body class="devise-registrations">
+<main class="auth-layout devise-registrations">
   <div class="auth-wrapper">
 
-    <%# Marca %>
     <div class="auth-brand">
       <div class="brand-icon">
         <svg viewBox="0 0 24 24">
@@ -276,7 +256,6 @@
 
       <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
 
-        <%# Dados pessoais %>
         <div class="fields-grid">
           <div class="field-group">
             <%= f.label :first_name, "Nome" %>
@@ -334,4 +313,4 @@
     </div>
 
   </div>
-</body>
+</main>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,26 +1,296 @@
-<h2>Log in</h2>
+<%# app/views/devise/sessions/new.html.erb %>
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=Fraunces:ital,wght@0,300;0,400;0,600;1,300&family=DM+Sans:wght@300;400;500&display=swap');
 
-<%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-  <div class="field">
-    <p><%= f.label :email %></p>
-    <p><%= f.email_field :email, autofocus: true, autocomplete: "email" %></p>
-  </div>
+  :root {
+    --verde:    #2D6A4F;
+    --verde-md: #40916C;
+    --verde-lt: #B7E4C7;
+    --creme:    #F8F4EE;
+    --terra:    #6B4226;
+    --texto:    #1A1A1A;
+    --cinza:    #6B7280;
+  }
 
-  <div class="field">
-    <p><%= f.label :password %></p>
-    <p><%= f.password_field :password, autocomplete: "current-password" %></p>
-  </div>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
 
-  <% if devise_mapping.rememberable? %>
-    <div class="field">
-      <p><%= f.check_box :remember_me %></p>
-      <p><%= f.label :remember_me %></p>
+  body.devise-sessions {
+    min-height: 100vh;
+    background-color: var(--creme);
+    font-family: 'DM Sans', sans-serif;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-image:
+      radial-gradient(ellipse 60% 50% at 10% 20%, rgba(45,106,79,.08) 0%, transparent 70%),
+      radial-gradient(ellipse 50% 60% at 90% 80%, rgba(64,145,108,.07) 0%, transparent 70%);
+    padding: 2rem 1rem;
+  }
+
+  .auth-wrapper {
+    width: 100%;
+    max-width: 420px;
+  }
+
+  /* ---- logo / marca ---- */
+  .auth-brand {
+    text-align: center;
+    margin-bottom: 2.5rem;
+  }
+
+  .auth-brand .brand-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 56px;
+    height: 56px;
+    background: var(--verde);
+    border-radius: 16px;
+    margin-bottom: 1rem;
+    box-shadow: 0 4px 16px rgba(45,106,79,.25);
+  }
+
+  .auth-brand .brand-icon svg {
+    width: 28px;
+    height: 28px;
+    color: #fff;
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 2;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
+
+  .auth-brand h1 {
+    font-family: 'Fraunces', serif;
+    font-weight: 600;
+    font-size: 1.5rem;
+    color: var(--texto);
+    line-height: 1.2;
+  }
+
+  .auth-brand p {
+    font-size: .875rem;
+    color: var(--cinza);
+    margin-top: .35rem;
+  }
+
+  /* ---- card ---- */
+  .auth-card {
+    background: #fff;
+    border-radius: 20px;
+    padding: 2.5rem 2.25rem;
+    box-shadow:
+      0 1px 3px rgba(0,0,0,.04),
+      0 8px 32px rgba(0,0,0,.07);
+    border: 1px solid rgba(0,0,0,.055);
+  }
+
+  .auth-card h2 {
+    font-family: 'Fraunces', serif;
+    font-weight: 400;
+    font-size: 1.6rem;
+    color: var(--texto);
+    margin-bottom: 1.75rem;
+  }
+
+  /* ---- erros Devise ---- */
+  .auth-errors {
+    background: #FEF2F2;
+    border: 1px solid #FECACA;
+    border-radius: 10px;
+    padding: .85rem 1rem;
+    margin-bottom: 1.25rem;
+    font-size: .85rem;
+    color: #B91C1C;
+  }
+
+  .auth-errors ul { padding-left: 1.1rem; }
+  .auth-errors li { margin-top: .2rem; }
+
+  /* ---- grupo de campo ---- */
+  .field-group {
+    margin-bottom: 1.25rem;
+  }
+
+  .field-group label {
+    display: block;
+    font-size: .8rem;
+    font-weight: 500;
+    letter-spacing: .04em;
+    text-transform: uppercase;
+    color: var(--cinza);
+    margin-bottom: .45rem;
+  }
+
+  .field-group input[type="email"],
+  .field-group input[type="password"],
+  .field-group input[type="text"] {
+    width: 100%;
+    padding: .7rem .95rem;
+    border: 1.5px solid #E5E7EB;
+    border-radius: 10px;
+    font-family: 'DM Sans', sans-serif;
+    font-size: .95rem;
+    color: var(--texto);
+    background: #FAFAFA;
+    transition: border-color .18s, box-shadow .18s, background .18s;
+    outline: none;
+  }
+
+  .field-group input:focus {
+    border-color: var(--verde-md);
+    background: #fff;
+    box-shadow: 0 0 0 3px rgba(64,145,108,.12);
+  }
+
+  /* ---- remember me ---- */
+  .remember-row {
+    display: flex;
+    align-items: center;
+    gap: .55rem;
+    margin-bottom: 1.75rem;
+  }
+
+  .remember-row input[type="checkbox"] {
+    width: 16px;
+    height: 16px;
+    accent-color: var(--verde);
+    cursor: pointer;
+  }
+
+  .remember-row label {
+    font-size: .875rem;
+    color: var(--cinza);
+    cursor: pointer;
+  }
+
+  /* ---- botão principal ---- */
+  .btn-primary-auth {
+    display: block;
+    width: 100%;
+    padding: .8rem;
+    background: var(--verde);
+    color: #fff;
+    border: none;
+    border-radius: 10px;
+    font-family: 'DM Sans', sans-serif;
+    font-size: .95rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: background .18s, transform .12s, box-shadow .18s;
+    box-shadow: 0 2px 8px rgba(45,106,79,.25);
+  }
+
+  .btn-primary-auth:hover {
+    background: var(--verde-md);
+    box-shadow: 0 4px 16px rgba(45,106,79,.3);
+    transform: translateY(-1px);
+  }
+
+  .btn-primary-auth:active {
+    transform: translateY(0);
+  }
+
+  /* ---- links de rodapé ---- */
+  .auth-links {
+    margin-top: 1.5rem;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: .6rem;
+    font-size: .875rem;
+  }
+
+  .auth-links a {
+    color: var(--verde);
+    text-decoration: none;
+    font-weight: 500;
+    transition: color .15s;
+  }
+
+  .auth-links a:hover {
+    color: var(--verde-md);
+    text-decoration: underline;
+  }
+
+  .auth-links .divider {
+    color: #D1D5DB;
+  }
+
+  .auth-links .row {
+    display: flex;
+    align-items: center;
+    gap: .5rem;
+  }
+
+  .auth-links .muted {
+    color: var(--cinza);
+  }
+</style>
+
+<body class="devise-sessions">
+  <div class="auth-wrapper">
+
+    <%# Marca / logo %>
+    <div class="auth-brand">
+      <div class="brand-icon">
+        <svg viewBox="0 0 24 24">
+          <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/>
+          <polyline points="9 22 9 12 15 12 15 22"/>
+        </svg>
+      </div>
+      <h1>Gestão de Repúblicas</h1>
+      <p>Controle financeiro da sua república</p>
     </div>
-  <% end %>
 
-  <div class="actions">
-    <%= f.submit "Log in" %>
+    <%# Card de login %>
+    <div class="auth-card">
+      <h2>Entrar</h2>
+
+      <%# Mensagens de erro do Devise %>
+      <% if resource.errors.any? %>
+        <div class="auth-errors">
+          <strong><%= pluralize(resource.errors.count, "erro") %> encontrado<%= resource.errors.count > 1 ? "s" : "" %>:</strong>
+          <ul>
+            <% resource.errors.full_messages.each do |msg| %>
+              <li><%= msg %></li>
+            <% end %>
+          </ul>
+        </div>
+      <% end %>
+
+      <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+
+        <div class="field-group">
+          <%= f.label :email, "E-mail" %>
+          <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+        </div>
+
+        <div class="field-group">
+          <%= f.label :password, "Senha" %>
+          <%= f.password_field :password, autocomplete: "current-password" %>
+        </div>
+
+        <% if devise_mapping.rememberable? %>
+          <div class="remember-row">
+            <%= f.check_box :remember_me %>
+            <%= f.label :remember_me, "Lembrar de mim" %>
+          </div>
+        <% end %>
+
+        <%= f.submit "Entrar", class: "btn-primary-auth" %>
+
+      <% end %>
+
+      <div class="auth-links">
+        <div class="row">
+          <span class="muted">Ainda não tem conta?</span>
+          <%= link_to "Criar conta", new_registration_path(resource_name) %>
+        </div>
+        <%= link_to "Esqueceu sua senha?", new_password_path(resource_name) %>
+      </div>
+    </div>
+
   </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</body>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -7,23 +7,25 @@
     --verde-md: #40916C;
     --verde-lt: #B7E4C7;
     --creme:    #F8F4EE;
-    --terra:    #6B4226;
     --texto:    #1A1A1A;
     --cinza:    #6B7280;
   }
 
   * { box-sizing: border-box; margin: 0; padding: 0; }
 
-  body.devise-sessions {
-    min-height: 100vh;
+  body {
     background-color: var(--creme);
-    font-family: 'DM Sans', sans-serif;
-    display: flex;
-    align-items: center;
-    justify-content: center;
     background-image:
       radial-gradient(ellipse 60% 50% at 10% 20%, rgba(45,106,79,.08) 0%, transparent 70%),
       radial-gradient(ellipse 50% 60% at 90% 80%, rgba(64,145,108,.07) 0%, transparent 70%);
+    font-family: 'DM Sans', sans-serif;
+  }
+
+  .auth-layout {
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     padding: 2rem 1rem;
   }
 
@@ -32,7 +34,6 @@
     max-width: 420px;
   }
 
-  /* ---- logo / marca ---- */
   .auth-brand {
     text-align: center;
     margin-bottom: 2.5rem;
@@ -75,7 +76,6 @@
     margin-top: .35rem;
   }
 
-  /* ---- card ---- */
   .auth-card {
     background: #fff;
     border-radius: 20px;
@@ -94,7 +94,6 @@
     margin-bottom: 1.75rem;
   }
 
-  /* ---- erros Devise ---- */
   .auth-errors {
     background: #FEF2F2;
     border: 1px solid #FECACA;
@@ -108,10 +107,7 @@
   .auth-errors ul { padding-left: 1.1rem; }
   .auth-errors li { margin-top: .2rem; }
 
-  /* ---- grupo de campo ---- */
-  .field-group {
-    margin-bottom: 1.25rem;
-  }
+  .field-group { margin-bottom: 1.25rem; }
 
   .field-group label {
     display: block;
@@ -144,7 +140,6 @@
     box-shadow: 0 0 0 3px rgba(64,145,108,.12);
   }
 
-  /* ---- remember me ---- */
   .remember-row {
     display: flex;
     align-items: center;
@@ -165,7 +160,6 @@
     cursor: pointer;
   }
 
-  /* ---- botão principal ---- */
   .btn-primary-auth {
     display: block;
     width: 100%;
@@ -188,11 +182,8 @@
     transform: translateY(-1px);
   }
 
-  .btn-primary-auth:active {
-    transform: translateY(0);
-  }
+  .btn-primary-auth:active { transform: translateY(0); }
 
-  /* ---- links de rodapé ---- */
   .auth-links {
     margin-top: 1.5rem;
     display: flex;
@@ -214,25 +205,18 @@
     text-decoration: underline;
   }
 
-  .auth-links .divider {
-    color: #D1D5DB;
-  }
-
   .auth-links .row {
     display: flex;
     align-items: center;
     gap: .5rem;
   }
 
-  .auth-links .muted {
-    color: var(--cinza);
-  }
+  .auth-links .muted { color: var(--cinza); }
 </style>
 
-<body class="devise-sessions">
+<main class="auth-layout devise-sessions">
   <div class="auth-wrapper">
 
-    <%# Marca / logo %>
     <div class="auth-brand">
       <div class="brand-icon">
         <svg viewBox="0 0 24 24">
@@ -244,11 +228,9 @@
       <p>Controle financeiro da sua república</p>
     </div>
 
-    <%# Card de login %>
     <div class="auth-card">
       <h2>Entrar</h2>
 
-      <%# Mensagens de erro do Devise %>
       <% if resource.errors.any? %>
         <div class="auth-errors">
           <strong><%= pluralize(resource.errors.count, "erro") %> encontrado<%= resource.errors.count > 1 ? "s" : "" %>:</strong>
@@ -293,4 +275,4 @@
     </div>
 
   </div>
-</body>
+</main>


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h2>Estilização das páginas de autenticação</h2>
<h3>Descrição</h3>
<p>Implementa a estilização visual das páginas de <strong>login</strong>, <strong>cadastro</strong> e <strong>redefinição de senha</strong>, que até então exibiam apenas o HTML padrão sem nenhuma identidade visual.</p>
<p>As três telas agora seguem um design coeso com paleta verde/creme, tipografia diferenciada e layout centralizado em card — mantendo toda a lógica Devise intacta.</p>
<hr>
<h3>Páginas alteradas</h3>

Arquivo | Rota
-- | --
app/views/devise/sessions/new.html.erb | /login
app/views/devise/registrations/new.html.erb | /register
app/views/devise/passwords/new.html.erb | /password/new


<hr>
<h3>O que foi feito</h3>
<ul>
<li>Layout centralizado em card branco com fundo creme e gradientes suaves</li>
<li>Logo/ícone de casa com identidade do sistema no topo de cada tela</li>
<li>Tipografia: <code>Fraunces</code> (títulos) + <code>DM Sans</code> (corpo), via Google Fonts</li>
<li>Campos com estados de foco estilizados (borda verde + sombra suave)</li>
<li>Todos os textos traduzidos para português (<code>Log in</code> → <code>Entrar</code>, <code>Sign up</code> → <code>Criar conta</code>, etc.)</li>
<li>Grid de 2 colunas no cadastro para Nome/Sobrenome e Telefone/CPF</li>
<li>Dicas de formato abaixo dos campos de telefone e CPF</li>
<li>Ícone de cadeado na tela de redefinição de senha</li>
<li>Navegação entre telas com links claros (ex: "Voltar para o login" com seta)</li>
<li>Layout responsivo para telas menores (mobile)</li>
</ul>
<hr>
<h3>O que não foi alterado</h3>
<ul>
<li>Nenhuma lógica de autenticação foi modificada</li>
<li>A estrutura dos formulários Devise (<code>form_for</code>, <code>resource</code>, <code>resource_name</code>) permanece intacta</li>
<li>Nenhuma gem nova foi adicionada</li>
<li>Os testes existentes continuam passando</li>
</ul>
<hr>
<h3>Checklist</h3>
<ul>
<li>[ ] Login estilizado (<code>/login</code>)</li>
<li>[ ] Cadastro estilizado (<code>/register</code>)</li>
<li>[ ] Redefinição de senha estilizada (<code>/password/new</code>)</li>
<li>[ ] Textos em português em todas as telas</li>
<li>[ ] Layout responsivo verificado</li>
<li>[ ] Testes passando (<code>bundle exec rspec</code>)</li>
<li>[ ] Sem regressões visuais nas demais páginas</li>
</ul></body></html><!--EndFragment-->
</body>
</html>