### PR TITLE
feat: US03 - CRUD de república (cadastro da casa)

### DIFF
--- a/app/controllers/republicas_controller.rb
+++ b/app/controllers/republicas_controller.rb
@@ -1,0 +1,51 @@
+class RepublicasController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_republica, only: [ :show, :edit, :update, :destroy ]
+
+  def index
+    @republicas = current_user.republicas.order(:name)
+  end
+
+  def show
+  end
+
+  def new
+    @republica = current_user.republicas.build
+  end
+
+  def edit
+  end
+
+  def create
+    @republica = current_user.republicas.build(republica_params)
+
+    if @republica.save
+      redirect_to @republica, notice: "República criada com sucesso."
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def update
+    if @republica.update(republica_params)
+      redirect_to @republica, notice: "República atualizada com sucesso."
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @republica.destroy
+    redirect_to republicas_url, notice: "República removida."
+  end
+
+  private
+
+  def set_republica
+    @republica = current_user.republicas.find(params[:id])
+  end
+
+  def republica_params
+    params.require(:republica).permit(:name, :endereco, :descricao)
+  end
+end

--- a/app/models/republica.rb
+++ b/app/models/republica.rb
@@ -1,0 +1,5 @@
+class Republica < ApplicationRecord
+  belongs_to :user
+
+  validates :name, presence: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ApplicationRecord
+  has_many :republicas, dependent: :destroy
+
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,6 +1,11 @@
-<h1>Bem-vindo, <%= current_user.first_name %>!</h1>
+<div class="container py-4">
+  <h1 class="h3 mb-3">Bem-vindo, <%= current_user.first_name %>!</h1>
 
-<%= button_to "Sair",
-              destroy_user_session_path,
-              method: :delete,
-              class: "btn btn-danger" %>
+  <div class="d-flex flex-wrap gap-2 mb-4">
+    <%= link_to "Minhas repúblicas", republicas_path, class: "btn btn-success" %>
+    <%= button_to "Sair",
+                  destroy_user_session_path,
+                  method: :delete,
+                  class: "btn btn-outline-danger" %>
+  </div>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,6 +24,14 @@
   </head>
 
   <body>
+    <% flash.each do |type, msg| %>
+      <% css = type.to_s == "notice" ? "success" : "danger" %>
+      <% next if msg.blank? %>
+      <div class="alert alert-<%= css %> alert-dismissible fade show rounded-0 mb-0" role="alert">
+        <%= msg %>
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Fechar"></button>
+      </div>
+    <% end %>
     <%= yield %>
   </body>
 </html>

--- a/app/views/republicas/_form.html.erb
+++ b/app/views/republicas/_form.html.erb
@@ -1,0 +1,32 @@
+<%= form_with model: republica, local: true do |f| %>
+  <% if republica.errors.any? %>
+    <div class="alert alert-danger" role="alert">
+      <strong><%= pluralize(republica.errors.count, "erro") %> impediu <%= republica.persisted? ? "a atualização" : "o cadastro" %>:</strong>
+      <ul class="mb-0 mt-2">
+        <% republica.errors.full_messages.each do |msg| %>
+          <li><%= msg %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="mb-3">
+    <%= f.label :name, "Nome da república", class: "form-label" %>
+    <%= f.text_field :name, class: "form-control", required: true, autofocus: true %>
+  </div>
+
+  <div class="mb-3">
+    <%= f.label :endereco, "Endereço", class: "form-label" %>
+    <%= f.text_field :endereco, class: "form-control", placeholder: "Opcional" %>
+  </div>
+
+  <div class="mb-3">
+    <%= f.label :descricao, "Descrição", class: "form-label" %>
+    <%= f.text_area :descricao, class: "form-control", rows: 4, placeholder: "Opcional — regras da casa, número de vagas, etc." %>
+  </div>
+
+  <div class="d-flex gap-2">
+    <%= f.submit republica.persisted? ? "Salvar alterações" : "Cadastrar república", class: "btn btn-success" %>
+    <%= link_to "Cancelar", republica.persisted? ? republica_path(republica) : republicas_path, class: "btn btn-outline-secondary" %>
+  </div>
+<% end %>

--- a/app/views/republicas/edit.html.erb
+++ b/app/views/republicas/edit.html.erb
@@ -1,0 +1,6 @@
+<% content_for :title, "Editar #{@republica.name}" %>
+
+<div class="container py-4" style="max-width: 640px;">
+  <h1 class="h3 mb-4">Editar república</h1>
+  <%= render "form", republica: @republica %>
+</div>

--- a/app/views/republicas/index.html.erb
+++ b/app/views/republicas/index.html.erb
@@ -1,0 +1,33 @@
+<% content_for :title, "Repúblicas" %>
+
+<div class="container py-4">
+  <div class="d-flex justify-content-between align-items-center mb-4 flex-wrap gap-2">
+    <h1 class="h3 mb-0">Minhas repúblicas</h1>
+    <%= link_to "Nova república", new_republica_path, class: "btn btn-success" %>
+  </div>
+
+  <% if @republicas.any? %>
+    <div class="list-group">
+      <% @republicas.each do |rep| %>
+        <%= link_to republica_path(rep), class: "list-group-item list-group-item-action d-flex justify-content-between align-items-start" do %>
+          <div>
+            <span class="fw-semibold"><%= rep.name %></span>
+            <% if rep.endereco.present? %>
+              <div class="small text-muted"><%= rep.endereco %></div>
+            <% end %>
+          </div>
+          <span class="badge text-bg-secondary rounded-pill">ver</span>
+        <% end %>
+      <% end %>
+    </div>
+  <% else %>
+    <div class="alert alert-info">
+      Você ainda não cadastrou nenhuma república.
+      <%= link_to "Criar a primeira", new_republica_path, class: "alert-link" %>.
+    </div>
+  <% end %>
+
+  <p class="mt-4 mb-0">
+    <%= link_to "← Voltar ao início", authenticated_root_path, class: "link-secondary" %>
+  </p>
+</div>

--- a/app/views/republicas/new.html.erb
+++ b/app/views/republicas/new.html.erb
@@ -1,0 +1,6 @@
+<% content_for :title, "Nova república" %>
+
+<div class="container py-4" style="max-width: 640px;">
+  <h1 class="h3 mb-4">Nova república</h1>
+  <%= render "form", republica: @republica %>
+</div>

--- a/app/views/republicas/show.html.erb
+++ b/app/views/republicas/show.html.erb
@@ -1,0 +1,30 @@
+<% content_for :title, @republica.name %>
+
+<div class="container py-4">
+  <div class="d-flex justify-content-between align-items-start flex-wrap gap-2 mb-3">
+    <div>
+      <h1 class="h3 mb-1"><%= @republica.name %></h1>
+      <% if @republica.endereco.present? %>
+        <p class="text-muted mb-0"><%= @republica.endereco %></p>
+      <% end %>
+    </div>
+    <div class="btn-group">
+      <%= link_to "Editar", edit_republica_path(@republica), class: "btn btn-outline-primary btn-sm" %>
+      <%= button_to "Excluir", republica_path(@republica), method: :delete, class: "btn btn-outline-danger btn-sm",
+            form: { data: { turbo_confirm: "Tem certeza que deseja excluir esta república?" } } %>
+    </div>
+  </div>
+
+  <% if @republica.descricao.present? %>
+    <div class="card mb-4">
+      <div class="card-body">
+        <h2 class="h6 text-muted">Descrição</h2>
+        <p class="card-text mb-0"><%= simple_format(@republica.descricao) %></p>
+      </div>
+    </div>
+  <% end %>
+
+  <p class="mb-0">
+    <%= link_to "← Lista de repúblicas", republicas_path, class: "link-secondary" %>
+  </p>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,9 @@ Rails.application.routes.draw do
                 sign_up: "register"
               }
 
+  # Repúblicas: rotas sempre registradas; o controller exige login (redirect 302).
+  resources :republicas
+
   authenticated :user do
     root "home#index", as: :authenticated_root
   end

--- a/db/migrate/20260422025755_create_republicas.rb
+++ b/db/migrate/20260422025755_create_republicas.rb
@@ -1,0 +1,12 @@
+class CreateRepublicas < ActiveRecord::Migration[8.1]
+  def change
+    create_table :republicas do |t|
+      t.string :name, null: false
+      t.string :endereco
+      t.text :descricao
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_19_231625) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_22_025755) do
+  create_table "republicas", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.text "descricao"
+    t.string "endereco"
+    t.string "name", null: false
+    t.datetime "updated_at", null: false
+    t.integer "user_id", null: false
+    t.index ["user_id"], name: "index_republicas_on_user_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "document", null: false
@@ -31,4 +41,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_19_231625) do
     t.index ["phone"], name: "index_users_on_phone", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
+
+  add_foreign_key "republicas", "users"
 end

--- a/spec/factories/republicas.rb
+++ b/spec/factories/republicas.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :republica do
+    sequence(:name) { |n| "República #{n}" }
+    endereco { "Rua das Flores, 100 — Lavras/MG" }
+    descricao { "República estudantil para testes." }
+    association :user
+  end
+end

--- a/spec/models/republica_spec.rb
+++ b/spec/models/republica_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.describe Republica, type: :model do
+  describe "associações" do
+    it "pertence a um usuário" do
+      republica = create(:republica)
+      expect(republica.user).to be_a(User)
+    end
+  end
+
+  describe "validações" do
+    it "exige nome" do
+      republica = build(:republica, name: "")
+      expect(republica).not_to be_valid
+      expect(republica.errors[:name]).to include("can't be blank")
+    end
+
+    it "é válida com atributos da factory" do
+      expect(build(:republica)).to be_valid
+    end
+  end
+end

--- a/spec/requests/republicas_spec.rb
+++ b/spec/requests/republicas_spec.rb
@@ -1,0 +1,74 @@
+require "rails_helper"
+
+RSpec.describe "Republicas", type: :request do
+  let(:user) { create(:user, password: "123456", password_confirmation: "123456") }
+
+  describe "GET /republicas" do
+    it "redireciona visitante para login" do
+      get republicas_path
+      expect(response).to redirect_to(new_user_session_path)
+    end
+
+    it "lista repúblicas do usuário autenticado" do
+      rep = create(:republica, user: user, name: "Rep Alpha")
+
+      sign_in user
+      get republicas_path
+
+      expect(response).to have_http_status(:success)
+      expect(response.body).to include("Rep Alpha")
+    end
+  end
+
+  describe "fluxo CRUD" do
+    before { sign_in user }
+
+    it "cria, mostra, edita e remove uma república" do
+      get new_republica_path
+      expect(response).to have_http_status(:success)
+
+      expect do
+        post republicas_path, params: {
+          republica: {
+            name: "República Nova",
+            endereco: "Rua X",
+            descricao: "Descrição."
+          }
+        }
+      end.to change(Republica, :count).by(1)
+
+      republica = Republica.order(:created_at).last
+      expect(response).to redirect_to(republica_path(republica))
+      follow_redirect!
+
+      get edit_republica_path(republica)
+      expect(response).to have_http_status(:success)
+
+      patch republica_path(republica), params: {
+        republica: { name: "República Atualizada", endereco: "Rua Y", descricao: "Nova desc." }
+      }
+      expect(response).to redirect_to(republica_path(republica))
+      expect(republica.reload.name).to eq("República Atualizada")
+
+      expect do
+        delete republica_path(republica)
+      end.to change(Republica, :count).by(-1)
+
+      expect(response).to redirect_to(republicas_url)
+    end
+
+    it "não permite acessar república de outro usuário" do
+      outro = create(
+        :user,
+        phone: "31988881111",
+        document: Faker::Number.unique.number(digits: 11).to_s,
+        email: Faker::Internet.unique.email
+      )
+      rep_outra = create(:republica, user: outro)
+
+      get republica_path(rep_outra)
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+end


### PR DESCRIPTION
## US03 — Cadastro/gestão da república

Entrega incremento de produto para a **Sprint 1** (mínimo 3 US): cadastro da entidade central do domínio (**república**), com telas navegáveis e testes.

### O que inclui
- Modelo `Republica` (`name` obrigatório; `endereco`, `descricao` opcionais) e `user_id`.
- `User` `has_many :republicas`.
- `RepublicasController` (REST) — cada usuário só vê/gerencia **as próprias** repúblicas (`current_user.republicas`).
- Rotas `resources :republicas` (fora do bloco `authenticated` no routes para guest receber **302** no `authenticate_user!`, não 404).
- Views com Bootstrap: index, show, new, edit; formulário parcial; exclusão com confirmação (Turbo).
- Flash de `notice`/`alert` no `application` layout.
- Home: link **Minhas repúblicas**.
- **RSpec**: modelo + requests (CRUD + tentativa de aceder república de outro utilizador → 404).

### Como testar localmente
```bash
bin/rails db:migrate
bin/rails server
```
Login → **Minhas repúblicas** → criar/editar/listar.

### Checklist Sprint 1 (calendário)
- [x] Funcionalidade demonstrável ao vivo (telas)
- [x] Testes a passar (`bundle exec rspec`)

/cc equipa para review antes do merge na `main`.