### PR TITLE
fix(pagamentos): corrigir totais pagos e pendentes invertidos

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -21,8 +21,9 @@ class DashboardController < ApplicationController
     @current_month_expenses = @despesas.where(vencimento: month_range)
     @current_month_expenses_total = @current_month_expenses.sum(:valor)
     @registered_expenses_total = @despesas.sum(:valor)
-    @paid_payments_total = Pagamento.where(despesa: @current_month_expenses).sum(:valor)
-    @pending_payments_total = [ @current_month_expenses_total - @paid_payments_total, 0.to_d ].max
+    month_payments = Pagamento.where(despesa: @current_month_expenses)
+    @paid_payments_total = month_payments.paid.sum(:valor)
+    @pending_payments_total = month_payments.pending.sum(:valor)
     @recent_expenses = @despesas.order(vencimento: :desc, created_at: :desc).limit(5)
     @total_por_morador = total_por_morador(@despesas, @residents)
   end

--- a/app/controllers/pagamentos_controller.rb
+++ b/app/controllers/pagamentos_controller.rb
@@ -62,7 +62,7 @@ class PagamentosController < ApplicationController
 
     @payment_rows = @residents.map do |resident|
       devido = @despesas.sum { |despesa| despesa.valor_por_morador || 0.to_d }
-      pago = @pagamentos.select { |pagamento| pagamento.resident_id == resident.id }.sum(&:valor)
+      pago = @pagamentos.select { |pagamento| pagamento.resident_id == resident.id && pagamento.paid? }.sum(&:valor)
       pendente = [ devido - pago, 0.to_d ].max
 
       {

--- a/app/controllers/republicas_controller.rb
+++ b/app/controllers/republicas_controller.rb
@@ -54,8 +54,9 @@ class RepublicasController < ApplicationController
     @current_month_expenses_total = @current_month_expenses.sum(:valor)
     @registered_expenses_total = @despesas.sum(:valor)
     @active_residents_count = @republica.residents.active.count
-    @paid_payments_total = Pagamento.where(despesa: @current_month_expenses).sum(:valor)
-    @pending_payments_total = [ @current_month_expenses_total - @paid_payments_total, 0.to_d ].max
+    month_payments = Pagamento.where(despesa: @current_month_expenses)
+    @paid_payments_total = month_payments.paid.sum(:valor)
+    @pending_payments_total = month_payments.pending.sum(:valor)
     @recent_expenses = @despesas.order(vencimento: :desc, created_at: :desc).limit(5)
   end
 

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -43,6 +43,8 @@ RSpec.describe "Dashboard", type: :request do
       # Total de despesas do mês atual: aluguel 1000 + internet 150 = 1150
       # Total pago: Ana (500 aluguel) + Bia e Ana (75 cada internet) = 500 + 75 + 75 = 650
       # Total pendente: Bia aluguel (500) = 500
+      expect(response.body).to include("$650.00")
+      expect(response.body).to include("$500.00")
       expect(response.body).to include("Moradores ativos")
       expect(response.body).to include(">2</p>")
       expect(response.body).not_to include("Despesa de outra casa")

--- a/spec/requests/pagamentos_spec.rb
+++ b/spec/requests/pagamentos_spec.rb
@@ -30,6 +30,21 @@ RSpec.describe "Pagamentos", type: :request do
       expect(response.body).to include("Pendente")
     end
 
+    it "separa totais pagos e pendentes pelo status do pagamento" do
+      pagamento_ana = despesa.pagamentos.find_by(resident: ana)
+      pagamento_bia = despesa.pagamentos.find_by(resident: bia)
+      pagamento_ana.update!(status: :paid)
+
+      sign_in user
+      get republica_pagamentos_path(republica, month: Date.current.month, year: Date.current.year)
+
+      expect(response.body).to include("Total pago")
+      expect(response.body).to include("Total pendente")
+      expect(response.body.scan(/\$100\.00/).size).to be >= 3
+      expect(pagamento_ana.reload).to be_paid
+      expect(pagamento_bia.reload).to be_pending
+    end
+
     it "filtra despesas por mês e não exibe dados de outras repúblicas" do
       create(:despesa, republica: republica, descricao: "Conta julho", valor: 200, vencimento: 1.month.from_now.to_date)
       create(:resident, name: "Morador externo")


### PR DESCRIPTION
## Summary
- Corrige o cálculo de totais pagos e pendentes na aba de pagamentos, no dashboard e no painel da república
- Antes, todos os pagamentos gerados automaticamente pelas despesas (status `pending`) eram somados como "pago"
- Agora os totais respeitam o `status` de cada registro (`paid` vs `pending`)

## Test plan
- [x] `rspec spec/requests/pagamentos_spec.rb spec/requests/dashboard_spec.rb`
- [ ] Abrir `/republicas/:id/pagamentos` e validar cards de Total pago / Total pendente
- [ ] Marcar um pagamento como pago e confirmar que os totais atualizam corretamente
- [ ] Conferir card de Pagamentos no dashboard


Made with [Cursor](https://cursor.com)